### PR TITLE
chorus: Added MakeWriteAction command to auto generate Write Actions.

### DIFF
--- a/packages/chorus/src/Console/Commands/MakeWriteActionCommand.php
+++ b/packages/chorus/src/Console/Commands/MakeWriteActionCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelsprout\LaravelChorus\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class MakeWriteActionCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'chorus:make-write-action {name : The name of the WriteAction class}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new WriteAction class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'WriteAction';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/writeaction.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Actions\WriteActions';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return array|string|string[]
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        return str_replace(['{{ class }}', '{{class}}'], $class, $stub);
+    }
+}

--- a/packages/chorus/src/Console/Commands/stubs/writeaction.stub
+++ b/packages/chorus/src/Console/Commands/stubs/writeaction.stub
@@ -1,0 +1,39 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Pixelsprout\LaravelChorus\Support\WriteAction;
+
+class {{ class }} extends WriteAction
+{
+    protected array $config = [
+        'allowOfflineWrites' => true,
+        'supportsBatch' => true,
+    ];
+
+    public function handle(Request $request, array $data): mixed
+    {
+        $user = auth()->user();
+
+        if (!$user) {
+            throw new \Exception('User must be authenticated');
+        }
+
+        // TODO: Implement your write action logic here
+
+        // Example:
+        // return Model::create([
+        //     'field' => $data['field'],
+        //     'user_id' => $user->id,
+        // ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            // TODO: Define your validation rules here
+            // 'field' => 'required|string|max:255',
+        ];
+    }
+}

--- a/packages/chorus/src/Providers/ChorusServiceProvider.php
+++ b/packages/chorus/src/Providers/ChorusServiceProvider.php
@@ -13,6 +13,7 @@ use Pixelsprout\LaravelChorus\Console\Commands\ChorusStart;
 use Pixelsprout\LaravelChorus\Console\Commands\ChorusInstall;
 use Pixelsprout\LaravelChorus\Console\Commands\ChorusGenerate;
 use Pixelsprout\LaravelChorus\Console\Commands\ChorusDebug;
+use Pixelsprout\LaravelChorus\Console\Commands\MakeWriteActionCommand;
 use Pixelsprout\LaravelChorus\Listeners\TrackChannelConnections;
 use Pixelsprout\LaravelChorus\Adapters\HarmonicSourceAdapterManager;
 use Pixelsprout\LaravelChorus\Support\WriteActionRegistry;
@@ -57,6 +58,7 @@ final class ChorusServiceProvider extends ServiceProvider
                 ChorusInstall::class,
                 ChorusGenerate::class,
                 ChorusDebug::class,
+                MakeWriteActionCommand::class,
             ]);
 
             // Publish migrations


### PR DESCRIPTION
You can now run:

```bash
php artisan chorus:make-write-action {name}';
```

This makes it easy to build out the required boilerplate for when creating an action.