### PR TITLE
chorus: Added MakePrefixResolver command to auto generate a prefix resolver

### DIFF
--- a/packages/chorus/src/Console/Commands/MakePrefixResolverCommand.php
+++ b/packages/chorus/src/Console/Commands/MakePrefixResolverCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelsprout\LaravelChorus\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class MakePrefixResolverCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'chorus:make-prefix-resolver {name : The name of the PrefixResolver class}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new PrefixResolver class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'PrefixResolver';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/prefixresolver.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Chorus\Resolvers';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return array|string|string[]
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        return str_replace(['{{ class }}', '{{class}}'], $class, $stub);
+    }
+}

--- a/packages/chorus/src/Console/Commands/stubs/prefixresolver.stub
+++ b/packages/chorus/src/Console/Commands/stubs/prefixresolver.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Model;
+use Pixelsprout\LaravelChorus\Contracts\PrefixResolver;
+
+class {{ class }} implements PrefixResolver
+{
+    public function resolve(Model $model): string
+    {
+        // TODO: Implement your prefix resolution logic here
+        
+        // Example: Return a prefix based on the model's tenant_id
+        // if ($model->tenant_id) {
+        //     return "tenant_{$model->tenant_id}";
+        // }
+        
+        // Example: Return a prefix based on the authenticated user
+        // $user = auth()->user();
+        // if ($user && $user->tenant_id) {
+        //     return "tenant_{$user->tenant_id}";
+        // }
+        
+        // Default fallback
+        return 'default';
+    }
+}

--- a/packages/chorus/src/Providers/ChorusServiceProvider.php
+++ b/packages/chorus/src/Providers/ChorusServiceProvider.php
@@ -14,6 +14,7 @@ use Pixelsprout\LaravelChorus\Console\Commands\ChorusInstall;
 use Pixelsprout\LaravelChorus\Console\Commands\ChorusGenerate;
 use Pixelsprout\LaravelChorus\Console\Commands\ChorusDebug;
 use Pixelsprout\LaravelChorus\Console\Commands\MakeWriteActionCommand;
+use Pixelsprout\LaravelChorus\Console\Commands\MakePrefixResolverCommand;
 use Pixelsprout\LaravelChorus\Listeners\TrackChannelConnections;
 use Pixelsprout\LaravelChorus\Adapters\HarmonicSourceAdapterManager;
 use Pixelsprout\LaravelChorus\Support\WriteActionRegistry;
@@ -59,6 +60,7 @@ final class ChorusServiceProvider extends ServiceProvider
                 ChorusGenerate::class,
                 ChorusDebug::class,
                 MakeWriteActionCommand::class,
+                MakePrefixResolverCommand::class,
             ]);
 
             // Publish migrations


### PR DESCRIPTION
You can run:

```bash
php artisan chorus:make-prefix-resolver {name}
```

This makes it easy to generate the boilerplate for creating a prefix resolver.