### PR TITLE
Improve Reverb detection and add auto-install for starter kits

### DIFF
--- a/packages/chorus/src/Console/Commands/ChorusInstall.php
+++ b/packages/chorus/src/Console/Commands/ChorusInstall.php
@@ -47,9 +47,9 @@ final class ChorusInstall extends Command
     {
         $this->info('Setting up broadcasting for Laravel Chorus...');
 
-        // Check if Reverb is already installed
-        if (File::exists(config_path('reverb.php'))) {
-            $this->info('Reverb is already installed.');
+        // Check if Reverb is already installed and configured
+        if (File::exists(config_path('reverb.php')) && $this->isReverbConfigured()) {
+            $this->info('Reverb is already installed and configured.');
 
             // Check if the reverb driver is configured
             $envFile = base_path('.env');
@@ -287,5 +287,19 @@ TS;
             }
             throw new Exception('Package manager command failed');
         }
+    }
+
+    private function isReverbConfigured(): bool
+    {
+        $envFile = base_path('.env');
+        
+        if (! File::exists($envFile)) {
+            return false;
+        }
+
+        $env = File::get($envFile);
+        
+        // Check if REVERB_APP_ID is present and has a value
+        return preg_match('/REVERB_APP_ID=.+/', $env) === 1;
     }
 }

--- a/packages/chorus/src/Console/Commands/ChorusInstall.php
+++ b/packages/chorus/src/Console/Commands/ChorusInstall.php
@@ -292,13 +292,13 @@ TS;
     private function isReverbConfigured(): bool
     {
         $envFile = base_path('.env');
-        
+
         if (! File::exists($envFile)) {
             return false;
         }
 
         $env = File::get($envFile);
-        
+
         // Check if REVERB_APP_ID is present and has a value
         return preg_match('/REVERB_APP_ID=.+/', $env) === 1;
     }

--- a/starter-kits/chorus-react-starter-kit/composer.json
+++ b/starter-kits/chorus-react-starter-kit/composer.json
@@ -53,6 +53,7 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
+            "@php artisan chorus:install",
             "@php artisan migrate --graceful --ansi"
         ],
         "dev": [


### PR DESCRIPTION
## Summary
- Enhanced ChorusInstall command to properly detect Reverb installation by checking for REVERB_APP_ID in .env file
- Added auto-install capability to chorus-react-starter-kit via post-create-project-cmd hook
- Fixed issue where Reverb was assumed installed based only on config file presence

## Changes Made
- Added `isReverbConfigured()` method to check for REVERB_APP_ID environment variable
- Updated Reverb detection logic to require both config file AND proper environment configuration
- Added `@php artisan chorus:install` to starter kit's post-create-project-cmd for automatic setup
- Maintained interactive prompts for user choice during installation

## Test plan
- [ ] Test starter kit creation with `laravel new test-app --using=pixelsprout/chorus-react-starter-kit`
- [ ] Verify Reverb detection works correctly when config exists but REVERB_APP_ID is missing
- [ ] Confirm interactive prompts still function during manual chorus:install runs
- [ ] Test that auto-install completes successfully during starter kit setup

🤖 Generated with [Claude Code](https://claude.ai/code)